### PR TITLE
Bump to 1.7.9

### DIFF
--- a/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/LoadOrderMiniTests.java
+++ b/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/LoadOrderMiniTests.java
@@ -51,10 +51,7 @@ public class LoadOrderMiniTests {
             return mixinEntries;
         };
 
-        try {
-            launchMixins(cl);
-            Assert.fail("Loading should have failed");
-        } catch (IllegalStateException expected) { }
+        launchMixins(cl);
     }
 
 

--- a/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/MirrorFieldsMixinTests.java
+++ b/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/MirrorFieldsMixinTests.java
@@ -12,7 +12,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URLClassLoader;
 
-import static fr.jydet.angler.MixinCompiler.*;
+import static fr.jydet.angler.MixinCompiler.compileAndLoad;
+import static fr.jydet.angler.MixinCompiler.getFilesFromMixinsTank;
 import static fr.jydet.angler.Utils.assertNumberOfClassesMixified;
 import static fr.jydet.angler.Utils.launchMixins;
 
@@ -34,6 +35,17 @@ public class MirrorFieldsMixinTests {
     @Test
     public void test_mirrorInternalFieldMixin() throws IOException {
         URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("MirrorInternalFieldMixin.java"));
+        launchMixins(cl);
+        assertNumberOfClassesMixified(1);
+        SimplePOJO simplePOJO = new SimplePOJO();
+        Assert.assertFalse(simplePOJO.getInternalAtomicBoolean().get());
+        simplePOJO.noopMethod();
+        Assert.assertTrue(simplePOJO.getInternalAtomicBoolean().get());
+    }
+
+    @Test
+    public void test_mirrorInternalFieldValueMixin() throws IOException {
+        URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("MirrorInternalFieldValueMixin.java"));
         launchMixins(cl);
         assertNumberOfClassesMixified(1);
         SimplePOJO simplePOJO = new SimplePOJO();
@@ -80,7 +92,9 @@ public class MirrorFieldsMixinTests {
         try {
             launchMixins(cl);
             Assert.fail("Mixin should be detected as invalid: A @Mirror field must not be final !");
-        } catch (InvalidMixinException expected) { }
+        } catch (InvalidMixinException expected) {
+            expected.printStackTrace();
+        }
     }
 
     @Test

--- a/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/MirrorMethodsMixinTests.java
+++ b/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/MirrorMethodsMixinTests.java
@@ -42,6 +42,17 @@ public class MirrorMethodsMixinTests {
     }
 
     @Test
+    public void test_mirrorInternalMethodValueMixin() throws IOException {
+        URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("MirrorInternalMethodValueMixin.java"));
+        launchMixins(cl);
+        assertNumberOfClassesMixified(1);
+        SimplePOJO simplePOJO = new SimplePOJO();
+        Assert.assertFalse(simplePOJO.getState().hasChanged());
+        simplePOJO.noopMethod();
+        Assert.assertTrue(simplePOJO.getState().hasChanged());
+    }
+
+    @Test
     public void test_mirrorUnknownInternalMethod() throws IOException {
         URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("MirrorUnknownMethodMixin.java"));
         launchMixins(cl);

--- a/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/SimpleMixinTests.java
+++ b/angler/fishing-ground/src/test/java/fr/jydet/angler/suite/SimpleMixinTests.java
@@ -4,6 +4,7 @@ import fr.jydet.angler.State;
 import fr.jydet.angler.Utils;
 import fr.jydet.angler.mixintargets.ReturnTestPOJO;
 import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.bytecode.InvalidMixinException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +28,35 @@ public class SimpleMixinTests {
     }
 
     /** BEGINNING INJECTION **/
+
+
+    @Test
+    public void test_injectBeforeWithoutLineNumber() throws IOException {
+        URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("InjectBeforeWithoutLineNumber.java"));
+        try {
+            launchMixins(cl);
+            Assert.fail("Mixin should create a runtime error when loading it !");
+        } catch (InvalidMixinException expected) { }
+    }
+
+    @Test
+    public void test_injectAfterWithoutLineNumber() throws IOException {
+        URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("InjectAfterWithoutLineNumber.java"));
+        try {
+            launchMixins(cl);
+            Assert.fail("Mixin should create a runtime error when loading it !");
+        } catch (InvalidMixinException expected) {
+        }
+    }
+
+    @Test
+    public void test_injectReplaceWithoutLineNumber() throws IOException {
+        URLClassLoader cl = compileAndLoad(getFilesFromMixinsTank("InjectReplaceWithoutLineNumber.java"));
+        try {
+            launchMixins(cl);
+            Assert.fail("Mixin should create a runtime error when loading it !");
+        } catch (InvalidMixinException expected) { }
+    }
 
     @Test
     public void test_injectBeginning_inEmptyMethod() throws IOException {

--- a/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectAfterWithoutLineNumber.java
+++ b/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectAfterWithoutLineNumber.java
@@ -1,0 +1,15 @@
+package fr.jydet.angler.mixin.inject.inject;
+
+import fr.jydet.angler.State;
+import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.Inject;
+import io.tunabytes.Mixin;
+
+@Mixin(SimplePOJO.class)
+public class InjectAfterWithoutLineNumber {
+
+    @Inject(method = "noopMethodWithInternalStateChangeCall", at = Inject.At.AFTER_LINE)
+    public void noopMethodWithInternalStateChangeCall() {
+        State.success = true;
+    }
+}

--- a/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectBeforeWithoutLineNumber.java
+++ b/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectBeforeWithoutLineNumber.java
@@ -1,0 +1,15 @@
+package fr.jydet.angler.mixin.inject.inject;
+
+import fr.jydet.angler.State;
+import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.Inject;
+import io.tunabytes.Mixin;
+
+@Mixin(SimplePOJO.class)
+public class InjectBeforeWithoutLineNumber {
+
+    @Inject(method = "noopMethodWithInternalStateChangeCall", at = Inject.At.BEFORE_LINE)
+    public void noopMethodWithInternalStateChangeCall() {
+        State.success = true;
+    }
+}

--- a/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectReplaceWithoutLineNumber.java
+++ b/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/inject/InjectReplaceWithoutLineNumber.java
@@ -1,0 +1,15 @@
+package fr.jydet.angler.mixin.inject.inject;
+
+import fr.jydet.angler.State;
+import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.Inject;
+import io.tunabytes.Mixin;
+
+@Mixin(SimplePOJO.class)
+public class InjectReplaceWithoutLineNumber {
+
+    @Inject(method = "noopMethodWithInternalStateChangeCall", at = Inject.At.REPLACE_LINE)
+    public void noopMethodWithInternalStateChangeCall() {
+        State.success = true;
+    }
+}

--- a/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/mirror/MirrorInternalFieldValueMixin.java
+++ b/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/mirror/MirrorInternalFieldValueMixin.java
@@ -1,0 +1,19 @@
+package fr.jydet.angler.mixin.inject.mirror;
+
+import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.Inject;
+import io.tunabytes.Mirror;
+import io.tunabytes.Mixin;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Mixin(SimplePOJO.class)
+public class MirrorInternalFieldValueMixin {
+
+    @Mirror("internalAtomicBoolean") AtomicBoolean xxxxxxxxxxxxxxxxxxxxx;
+
+    @Inject(method = "noopMethod", at = Inject.At.BEGINNING)
+    public void noopMethod() {
+        xxxxxxxxxxxxxxxxxxxxx.set(true);
+    }
+}

--- a/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/mirror/MirrorInternalMethodValueMixin.java
+++ b/angler/mixins-tank/src/main/java/fr/jydet/angler/mixin/inject/mirror/MirrorInternalMethodValueMixin.java
@@ -1,0 +1,19 @@
+package fr.jydet.angler.mixin.inject.mirror;
+
+import fr.jydet.angler.mixintargets.SimplePOJO;
+import io.tunabytes.Inject;
+import io.tunabytes.Mirror;
+import io.tunabytes.Mixin;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Mixin(SimplePOJO.class)
+public abstract class MirrorInternalMethodValueMixin {
+
+    @Mirror("internalMethodWithInternalStateChangeCall") public abstract void xxxxxxxxxxxxxxx();
+
+    @Inject(method = "noopMethod", at = Inject.At.BEGINNING)
+    public void noopMethod() {
+        xxxxxxxxxxxxxxx();
+    }
+}

--- a/angler/pom.xml
+++ b/angler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.arenareturns</groupId>
         <artifactId>tuna-bytes</artifactId>
-        <version>1.7.8</version>
+        <version>1.7.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,13 +7,13 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <lombok.version>1.18.26</lombok.version>
-        <base.version>1.7.8</base.version>
+        <base.version>1.7.9</base.version>
     </properties>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.arenareturns.tuna-bytes</groupId>
     <artifactId>core</artifactId>
-    <version>1.7.8</version>
+    <version>1.7.9</version>
 
     <description>ArenaReturns' fork of Tuna Bytes, an all-purpose mixins framework for Java bytecode manipulation at runtime, targeted at those with minimal understanding of the bytecode structure.</description>
     <url>https://github.com/ArenaReturns/Tuna-Bytes</url>

--- a/core/src/main/java/io/tunabytes/Inject.java
+++ b/core/src/main/java/io/tunabytes/Inject.java
@@ -74,6 +74,7 @@ public @interface Inject {
     /**
      * Used with {@link At#REPLACE_LINE} to specify a range of lines to be replaced
      *  where the inclusive range is defined by [lineNumber,lineNumberEnd].
+     *  If not specified only the line at {{@link #lineNumber()}} will be replaced
      * <p>
      * Note: The line number must match the number in the source code. Since
      * line numbers are preserved into the bytecode as instructions when the class is
@@ -81,7 +82,7 @@ public @interface Inject {
      * most likely going to yield incorrect lines.
      * @return The last line number to be replaced
      */
-    int injectLineReplaceEnd() default -1;
+    int injectLineReplaceEnd() default Integer.MIN_VALUE;
 
     /**
     * By default, the last return of the method is not copied from the mixins 

--- a/core/src/main/java/io/tunabytes/bytecode/ClassNarrower.java
+++ b/core/src/main/java/io/tunabytes/bytecode/ClassNarrower.java
@@ -2,12 +2,13 @@ package io.tunabytes.bytecode;
 
 import io.tunabytes.bytecode.introspect.MixinInfo;
 import io.tunabytes.bytecode.introspect.MixinMethod;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for narrowing down the target method of a mixin.
@@ -19,22 +20,22 @@ public final class ClassNarrower {
      */
     public static boolean LOG_WORK_ONLY_ON_ERROR = true;
     
-    public static MethodNode tryNarrow(ClassNode originalNode, MixinInfo fullInfo, MixinMethod method) {
-        String injectIn = method.getInjectMethod();
-        List<MethodNode> collected = originalNode.methods.stream()
-                                         .filter(c -> c.name.equals(injectIn))
+    public static MethodNode tryNarrow(ClassNode clazzToMixin, MixinInfo fullInfo, MixinMethod method) {
+        String targetMethodName = method.getTargetMethodName();
+        List<MethodNode> collected = clazzToMixin.methods.stream()
+                                         .filter(c -> c.name.equals(targetMethodName))
                                          .collect(Collectors.toList());
         StringBuilder workTrace = new StringBuilder();
-        String error = " target method(s) found for mixin:\n\t" + fullInfo.getMixinName() + "#" + method.getInjectMethod() + "(...)\n\t\tpatching =>\n\t" +
-                           originalNode.name.replace("/", ".") + "#";
-        String targetMethodDescriptor = "..." + injectIn + "(...)";
+        String error = " target method(s) found for mixin:\n\t" + fullInfo.getMixinName() + "#" + targetMethodName + "(...)\n\t\tpatching =>\n\t" +
+                           clazzToMixin.name.replace("/", ".") + "#";
+        String targetMethodDescriptor = "..." + targetMethodName + "(...)";
         String tip = "";
         String argumentsStr = "";
         if (collected.size() > 1) {
             Type[] arguments = Type.getArgumentTypes(method.getRealDescriptor());
             Type[] substringArgument = Arrays.copyOf(arguments, Math.min(method.getLastParameterArgIndex(), arguments.length));
             argumentsStr = Arrays.stream(substringArgument).map(Type::toString).collect(Collectors.joining());
-            targetMethodDescriptor = "..." + injectIn + "(" + argumentsStr + ")";
+            targetMethodDescriptor = "..." + targetMethodName + "(" + argumentsStr + ")";
             workTrace.append("[info] " + collected.size() + error + targetMethodDescriptor +"\n\tTrying to narrowing it down with args: "
                                    + targetMethodDescriptor);
 

--- a/core/src/main/java/io/tunabytes/bytecode/InvalidMixinException.java
+++ b/core/src/main/java/io/tunabytes/bytecode/InvalidMixinException.java
@@ -5,8 +5,4 @@ public class InvalidMixinException extends RuntimeException {
     public InvalidMixinException(String message) {
         super(message);
     }
-
-    public InvalidMixinException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/core/src/main/java/io/tunabytes/bytecode/editor/DefinalizeEditor.java
+++ b/core/src/main/java/io/tunabytes/bytecode/editor/DefinalizeEditor.java
@@ -1,12 +1,12 @@
 package io.tunabytes.bytecode.editor;
 
+import io.tunabytes.bytecode.introspect.MixinField;
+import io.tunabytes.bytecode.introspect.MixinInfo;
 import io.tunabytes.bytecode.introspect.MixinMethod;
+import lombok.SneakyThrows;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
-import io.tunabytes.bytecode.introspect.MixinField;
-import io.tunabytes.bytecode.introspect.MixinInfo;
-import lombok.SneakyThrows;
 import org.objectweb.asm.tree.MethodNode;
 
 /**
@@ -14,18 +14,18 @@ import org.objectweb.asm.tree.MethodNode;
  */
 public class DefinalizeEditor implements MixinsEditor {
 
-    @SneakyThrows @Override public void edit(ClassNode node, MixinInfo info) {
-        for (MixinField field : info.getFields()) {
+    @SneakyThrows @Override public void edit(ClassNode originalClassNode, MixinInfo info) {
+        for (MixinField field : info.getMixinFields()) {
             if (field.isDefinalize() && field.isMirror()) {
-                FieldNode fnode = node.fields.stream().filter(c -> c.name.equals(field.getName())).findFirst()
-                        .orElseThrow(() -> new NoSuchFieldException(field.getName()));
+                FieldNode fnode = originalClassNode.fields.stream().filter(c -> c.name.equals(field.getTargetFieldName())).findFirst()
+                        .orElseThrow(() -> new NoSuchFieldException(field.getTargetFieldName()));
                 fnode.access &= ~Opcodes.ACC_FINAL;
             }
         }
-        for (MixinMethod method : info.getMethods()) {
+        for (MixinMethod method : info.getMixinMethods()) {
             if (method.isDefinalize() && method.isMirror()) {
-                MethodNode mnode = node.methods.stream().filter(c -> c.name.equals(method.getName())).findFirst()
-                        .orElseThrow(() -> new NoSuchFieldException(method.getName()));
+                MethodNode mnode = originalClassNode.methods.stream().filter(c -> c.name.equals(method.getTargetMethodName())).findFirst()
+                        .orElseThrow(() -> new NoSuchFieldException(method.getTargetMethodName()));
                 mnode.access &= ~Opcodes.ACC_FINAL;
             }
         }

--- a/core/src/main/java/io/tunabytes/bytecode/editor/MethodMergerEditor.java
+++ b/core/src/main/java/io/tunabytes/bytecode/editor/MethodMergerEditor.java
@@ -16,20 +16,20 @@ public class MethodMergerEditor implements MixinsEditor {
 
     private static final Set<String> IGNORED_ENUM_METHODS = new HashSet<>(Arrays.asList("values", "valueOf", "<init>", "<clinit>"));
 
-    @Override public void edit(ClassNode classNode, MixinInfo info) {
-        for (MixinMethod method : info.getMethods()) {
+    @Override public void edit(ClassNode originalClassNode, MixinInfo info) {
+        for (MixinMethod method : info.getMixinMethods()) {
             if (method.isAccessor()) continue;
             if (method.isInject()) continue;
             if (method.isMirror()) continue;
             if (info.isMixinEnum()) {
-                if (IGNORED_ENUM_METHODS.contains(method.getName())) {
+                if (IGNORED_ENUM_METHODS.contains(method.getTargetMethodName())) {
                     continue;
                 }
             }
             //merge static initializer
             // inject no-args constructors into each constructor of the mixed class
-            if (method.getName().equals("<init>") || method.getName().equals("<clinit>")) {
-                merge(classNode, info, method, method.getName());
+            if (method.getTargetMethodName().equals("<init>") || method.getTargetMethodName().equals("<clinit>")) {
+                merge(originalClassNode, info, method, method.getTargetMethodName());
                 continue;
             }
             if (method.isOverwrite() || method.isRewrite()) continue;
@@ -39,9 +39,9 @@ public class MethodMergerEditor implements MixinsEditor {
             underlying.instructions = new InsnList();
             underlying.instructions.add(mn.instructions);
             for (AbstractInsnNode instruction : underlying.instructions) {
-                remapInstruction(classNode, info, instruction);
+                remapInstruction(originalClassNode, info, instruction);
             }
-            classNode.methods.add(underlying);
+            originalClassNode.methods.add(underlying);
         }
     }
 

--- a/core/src/main/java/io/tunabytes/bytecode/editor/RewriteEditor.java
+++ b/core/src/main/java/io/tunabytes/bytecode/editor/RewriteEditor.java
@@ -1,5 +1,6 @@
 package io.tunabytes.bytecode.editor;
 
+import io.tunabytes.bytecode.ClassNarrower;
 import io.tunabytes.bytecode.introspect.MixinInfo;
 import io.tunabytes.bytecode.introspect.MixinMethod;
 import lombok.SneakyThrows;
@@ -14,25 +15,19 @@ public class RewriteEditor implements MixinsEditor {
 
   @Override
   @SneakyThrows
-  public void edit(ClassNode classNode, MixinInfo info) {
-      for (MixinMethod method : info.getMethods()) {
-        if (!method.isRewrite()) continue;
-        if ((method.getMethodNode().access & ACC_ABSTRACT) == 0) {
-          throw new IllegalArgumentException("@Rewrite must be used on abstract methods! (" + method.getMethodNode().name + " in " + info.getMixinName() + ")");
-        }
-        MethodNode node = method.getMethodNode();
-        MethodNode underlying = classNode.methods.stream()
-            .filter(c -> c.name.equals(method.getOverwrittenName()) && c.desc.equals(node.desc))
-            .findFirst().orElseThrow(() -> new NoSuchMethodException(method.getOverwrittenName()));
+  public void edit(ClassNode originalClassNode, MixinInfo info) {
+      for (MixinMethod mixinMethod : info.getMixinMethods()) {
+        if (!mixinMethod.isRewrite()) continue;
+        MethodNode underlying = ClassNarrower.tryNarrow(originalClassNode, info, mixinMethod);
         
         try {
-          method.getRewritter().newInstance().rewrite(underlying);
+          mixinMethod.getRewritter().newInstance().rewrite(underlying);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
         
         for (AbstractInsnNode instruction : underlying.instructions) {
-          remapInstruction(classNode, info, instruction);
+          remapInstruction(originalClassNode, info, instruction);
         }
       }
     }

--- a/core/src/main/java/io/tunabytes/bytecode/introspect/MixinClassVisitor.java
+++ b/core/src/main/java/io/tunabytes/bytecode/introspect/MixinClassVisitor.java
@@ -4,12 +4,7 @@ import io.tunabytes.Mixin;
 import io.tunabytes.bytecode.InvalidMixinException;
 import io.tunabytes.bytecode.introspect.MixinMethod.CallType;
 import lombok.Getter;
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.objectweb.asm.*;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -27,8 +22,8 @@ public class MixinClassVisitor extends ClassVisitor {
     @Getter
     private boolean hasMirroredParent;
     protected Set<String> deletedEnumValues = new HashSet<>();
+    @Getter
     private String name;
-
     @Getter
     private MixinInfo info;
 
@@ -37,11 +32,21 @@ public class MixinClassVisitor extends ClassVisitor {
     }
 
     @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        super.visit(version, access, name, signature, superName, interfaces);
+        if ((access & Opcodes.ACC_INTERFACE) != 0)
+            isInterface = true;
+        this.name = name.replace('/', '.');
+        Collections.addAll(this.interfaceToAdd, interfaces);
+    }
+
+    @Override
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
         if (MIXIN.getDescriptor().equals(descriptor)) {
             return new AnnotationVisitor(Opcodes.ASM8) {
                 @Override
                 public void visit(String name, Object value) {
+                    super.visit(name, value);
                     if ("addAllInterfacesToMixins".equals(name)) {
                         addAllInterfacesToMixins = (boolean) value;
                     } else if ("withFakeParentAccessor".equals(name)) {
@@ -64,17 +69,8 @@ public class MixinClassVisitor extends ClassVisitor {
     }
 
     @Override
-    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-        if ((access & Opcodes.ACC_INTERFACE) != 0)
-            isInterface = true;
-        this.name = name.replace('/', '.');
-        Collections.addAll(this.interfaceToAdd, interfaces);
-        super.visit(version, access, name, signature, superName, interfaces);
-    }
-
-    @Override
     public FieldVisitor visitField(int access, String fname, String descriptor, String signature, Object value) {
-        return new MixinFieldVisitor(new FieldNode(access, fname, descriptor, signature, value)) {
+        return new MixinFieldVisitor(this, new FieldNode(access, fname, descriptor, signature, value)) {
             @Override
             public void visitEnd() {
                 FieldNode node = (FieldNode) fv;
@@ -88,21 +84,21 @@ public class MixinClassVisitor extends ClassVisitor {
     }
 
     @Override
-    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-        return new MixinMethodVisitor(new MethodNode(access, name, descriptor, signature, exceptions)) {
+    public MethodVisitor visitMethod(int access, String visitedMethodName, String descriptor, String signature, String[] exceptions) {
+         return new MixinMethodVisitor(this, new MethodNode(access, visitedMethodName, descriptor, signature, exceptions)) {
             @Override
             public void visitEnd() {
+                super.visitEnd();
                 Type desc = Type.getMethodType(returnType, argumentTypes);
-                node.desc = desc.getDescriptor();
+                mixinMethodNode.desc = desc.getDescriptor();
                 methods.add(new MixinMethod(
-                        name,
+                        targetMethodName,
                         access,
                         desc,
                         descriptor,
                         injectLine,
                         injectLineReplaceEnd,
                         manualInstructionSkip,
-                        injectMethodName,
                         lastParameterArgIndex,
                         injectAt,
                         overwrite,
@@ -111,13 +107,11 @@ public class MixinClassVisitor extends ClassVisitor {
                         inject,
                         mirror,
                         definalize,
-                        remap,
+                        requireTypeRemapping,
                         keepLastReturn,
-                        mirrorName == null ? name : mirrorName,
                         runtimeRewriter,
-                        overwrittenName == null ? name : overwrittenName,
-                        accessorName == null ? getActualName(name) : accessorName,
-                        node,
+                        accessorName == null ? getActualName(visitedMethodName) : accessorName,
+                        mixinMethodNode,
                         type == null ? CallType.INVOKE : type
                 ));
             }

--- a/core/src/main/java/io/tunabytes/bytecode/introspect/MixinField.java
+++ b/core/src/main/java/io/tunabytes/bytecode/introspect/MixinField.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.ToString;
 import org.objectweb.asm.tree.FieldNode;
 
-import java.util.Set;
-
 @Getter
 @ToString
 @AllArgsConstructor
@@ -15,7 +13,7 @@ public final class MixinField {
     private final int access;
     private final boolean mirror;
     private final boolean definalize;
-    private final String name, desc;
+    private final String targetFieldName, desc;
     private final boolean remapped;
     private final String enumField;
     private final String type;

--- a/core/src/main/java/io/tunabytes/bytecode/introspect/MixinInfo.java
+++ b/core/src/main/java/io/tunabytes/bytecode/introspect/MixinInfo.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -15,8 +14,8 @@ public class MixinInfo {
 
     private final String mixinName, mixinInternalName;
     private final boolean mixinInterface, mixinEnum, mirrorParent;
-    private final List<MixinField> fields;
-    private final List<MixinMethod> methods;
+    private final List<MixinField> mixinFields;
+    private final List<MixinMethod> mixinMethods;
     private final Set<String> deletedEnumValues;
     private final Set<String> interfacesToAdd;
 

--- a/core/src/main/java/io/tunabytes/bytecode/introspect/MixinMethod.java
+++ b/core/src/main/java/io/tunabytes/bytecode/introspect/MixinMethod.java
@@ -2,32 +2,29 @@ package io.tunabytes.bytecode.introspect;
 
 import io.tunabytes.Inject.At;
 import io.tunabytes.Rewrite.Rewritter;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.MethodNode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.MethodNode;
 
 @ToString
 @Getter
 @AllArgsConstructor
 public final class MixinMethod {
 
-    private final String name;
+    private final String targetMethodName;
     private final int access;
     private final Type descriptor;
     private final String realDescriptor;
     private final int injectLine;
     private final int injectLineReplaceEnd;
     private final int manualInstructionSkip;
-    private final String injectMethod;
     private final int lastParameterArgIndex;
     private final At injectAt;
     private final boolean overwrite, rewrite, accessor, inject, mirror, definalize, requireTypeRemapping, keepLastReturn;
-    private final String mirrorName;
     private final Class<? extends Rewritter> rewritter;
-    private final String overwrittenName; // or accessed method
     private final String accessedProperty; // or accessed method
     private final MethodNode methodNode;
     private final CallType type;

--- a/core/src/main/java/io/tunabytes/bytecode/introspect/MixinMethodVisitor.java
+++ b/core/src/main/java/io/tunabytes/bytecode/introspect/MixinMethodVisitor.java
@@ -1,13 +1,7 @@
 package io.tunabytes.bytecode.introspect;
 
-import io.tunabytes.Accessor;
-import io.tunabytes.ActualType;
-import io.tunabytes.Definalize;
-import io.tunabytes.Inject;
+import io.tunabytes.*;
 import io.tunabytes.Inject.At;
-import io.tunabytes.Mirror;
-import io.tunabytes.Overwrite;
-import io.tunabytes.Rewrite;
 import io.tunabytes.Rewrite.Rewritter;
 import io.tunabytes.bytecode.InvalidMixinException;
 import io.tunabytes.bytecode.introspect.MixinMethod.CallType;
@@ -16,6 +10,8 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodNode;
+
+import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
 
 public class MixinMethodVisitor extends MethodVisitor {
 
@@ -28,25 +24,25 @@ public class MixinMethodVisitor extends MethodVisitor {
     private static final String DEFINALIZE = Type.getDescriptor(Definalize.class);
     private static final String ACTUAL_TYPE = Type.getDescriptor(ActualType.class);
 
-    protected MethodNode node;
-    protected String mirrorName;
+    private final MixinClassVisitor mixinClassVisitor;
+    protected MethodNode mixinMethodNode;
     protected Type returnType;
     protected Type[] argumentTypes;
-    protected boolean overwrite, inject, accessor, mirror, definalize, remap, keepLastReturn, rewrite, forceLowerCase = true;
-    protected String overwrittenName;
-    protected String injectMethodName;
+    protected boolean overwrite, inject, accessor, mirror, definalize, requireTypeRemapping, keepLastReturn, rewrite, forceLowerCase = true;
+    protected String targetMethodName;
     protected Class<? extends Rewritter> runtimeRewriter;
     protected String accessorName;
-    protected int injectLine;
-    protected int injectLineReplaceEnd = -1;
+    protected int injectLine = 0;
+    protected int injectLineReplaceEnd = Integer.MIN_VALUE;
     protected int lastParameterArgIndex = Integer.MAX_VALUE;
     protected At injectAt;
     protected CallType type;
     protected int manualInstructionSkip = 0;
 
-    public MixinMethodVisitor(MethodNode node) {
+    public MixinMethodVisitor(MixinClassVisitor mixinClassVisitor, MethodNode node) {
         super(Opcodes.ASM8, node);
-        this.node = node;
+        this.mixinClassVisitor = mixinClassVisitor;
+        this.mixinMethodNode = node;
         Type desc = Type.getMethodType(node.desc);
         returnType = desc.getReturnType();
         argumentTypes = desc.getArgumentTypes();
@@ -87,6 +83,7 @@ public class MixinMethodVisitor extends MethodVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+        super.visitAnnotation(descriptor, visible);
         boolean visitingRewrite = REWRITE.equals(descriptor);
         boolean visitingAccessor = ACCESSOR.equals(descriptor);
         boolean visitingOverwrite = OVERWRITE.equals(descriptor);
@@ -101,7 +98,6 @@ public class MixinMethodVisitor extends MethodVisitor {
         }
         if (visitingInject) {
             inject = true;
-            injectMethodName = node.name;
         }
         if (visitingAccessor) {
             accessor = true;
@@ -126,24 +122,21 @@ public class MixinMethodVisitor extends MethodVisitor {
                             break;
                     }
                 }
-                if ((visitingRewrite || visitingOverwrite) && name.equals("value")) {
-                    overwrittenName = (String) value;
+                if ((visitingRewrite || visitingOverwrite || visitingMirror) && name.equals("value")) {
+                    targetMethodName = (String) value;
                 }
                 if (visitingRewrite && name.equals("runtimeRewriter")) {
                     runtimeRewriter = (Class<? extends Rewritter>) getClassForInternalName(((Type) value).getInternalName());
                 }
-                if (visitingMirror && name.equals("value")) {
-                    mirrorName = (String) value;
-                }
                 if (visitingActualType && name.equals("value")) {
-                    remap = true;
+                    requireTypeRemapping = true;
                     String rtype = returnType.getDescriptor();
                     returnType = fromActualType(rtype, (String) value);
                 }
                 if (visitingInject) {
                     switch (name) {
                         case "method": {
-                            injectMethodName = (String) value;
+                            targetMethodName = (String) value;
                             break;
                         }
                         case "returnType": {
@@ -179,11 +172,49 @@ public class MixinMethodVisitor extends MethodVisitor {
                     type = CallType.valueOf(value);
                 }
             }
+
+            @Override
+            public void visitEnd() {
+                super.visitEnd();
+                if (inject) {
+                    if (injectAt == At.BEFORE_LINE || injectAt == At.AFTER_LINE) {
+                        if (injectLineReplaceEnd != Integer.MIN_VALUE) {
+                            throw new InvalidMixinException("@Inject injectLineReplaceEnd must not be specified with injectAt mode " + injectAt + getErrorLocation());
+                        }
+                        if (injectLine < 1) {
+                            throw new InvalidMixinException("@Inject injectLine must be > 0" + getErrorLocation());
+                        }
+                    } else if (injectAt == At.REPLACE_LINE) {
+                        if (injectLine < 1) {
+                            throw new InvalidMixinException("@Inject injectLine must be > 0" + getErrorLocation());
+                        }
+                        //if not specified, we only replace the line at 'injectLine'
+                        if (injectLineReplaceEnd == Integer.MIN_VALUE) {
+                            injectLineReplaceEnd = injectLine;
+                        } else {
+                            if (injectLineReplaceEnd < injectLine) {
+                                throw new InvalidMixinException("@Inject injectLineReplaceEnd must be specified and >= injectLine (" + injectLine + ") " + getErrorLocation());
+                            }
+                        }
+                    }
+                }
+                if (overwrite && (mixinMethodNode.access & ACC_ABSTRACT) != 0) {
+                    throw new InvalidMixinException("@Overwrite cannot be used on abstract mixin methods!" + getErrorLocation());
+                }
+                if (rewrite && (mixinMethodNode.access & ACC_ABSTRACT) == 0) {
+                    throw new InvalidMixinException("@Rewrite must be used on abstract mixin methods! at " + getErrorLocation());
+                }
+            }
         };
+    }
+
+    private String getErrorLocation() {
+       return  " at " + mixinClassVisitor.getName() + '.' + mixinMethodNode.name + mixinMethodNode.desc;
     }
 
     @Override
     public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
+        super.visitParameterAnnotation(parameter, descriptor, visible);
 //        Important note: <i>a parameter index i
 //   *     is not required to correspond to the i'th parameter descriptor in the method
 //   *     descriptor</i>, in particular in case of synthetic parameters (see
@@ -193,13 +224,13 @@ public class MixinMethodVisitor extends MethodVisitor {
             if (lastParameterArgIndex == Integer.MAX_VALUE) {
                 lastParameterArgIndex = parameter;
             } else {
-                throw new InvalidMixinException("Double @StackSeparator annotation for method " + injectMethodName);
+                throw new InvalidMixinException("Double @StackSeparator annotation for method " + targetMethodName);
             }
         }
         return new AnnotationVisitor(Opcodes.ASM8, super.visitParameterAnnotation(parameter, descriptor, visible)) {
             @Override
             public void visit(String name, Object value) {
-                remap = true;
+                requireTypeRemapping = true;
                 if (ACTUAL_TYPE.equals(descriptor)) {
                     argumentTypes[parameter] = fromActualType(argumentTypes[parameter].getDescriptor(), (String) value);
                 }
@@ -244,5 +275,11 @@ public class MixinMethodVisitor extends MethodVisitor {
         return normalize(prefix, accessorName, forceLowerCase);
     }
 
-
+    @Override
+    public void visitEnd() {
+        super.visitEnd();
+        if (targetMethodName == null) {
+            targetMethodName = mixinMethodNode.name;
+        }
+    }
 }

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tuna-bytes</artifactId>
         <groupId>com.arenareturns</groupId>
-        <version>1.7.8</version>
+        <version>1.7.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.arenareturns.tuna-bytes</groupId>
             <artifactId>core</artifactId>
-            <version>1.7.8</version>
+            <version>1.7.9</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -7,14 +7,14 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <lombok.version>1.18.26</lombok.version>
-        <base.version>1.7.8</base.version>
+        <base.version>1.7.9</base.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.arenareturns.tuna-bytes</groupId>
     <artifactId>java8</artifactId>
-    <version>1.7.8</version>
+    <version>1.7.9</version>
 
     <description>ArenaReturns' fork of Tuna Bytes, an all-purpose mixins framework for Java bytecode manipulation at runtime, targeted at those with minimal understanding of the bytecode structure.</description>
     <url>https://github.com/ArenaReturns/Tuna-Bytes</url>

--- a/java9/pom.xml
+++ b/java9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tuna-bytes</artifactId>
         <groupId>com.arenareturns</groupId>
-        <version>1.7.8</version>
+        <version>1.7.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.arenareturns.tuna-bytes</groupId>
             <artifactId>core</artifactId>
-            <version>1.7.8</version>
+            <version>1.7.9</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     <groupId>com.arenareturns</groupId>
     <artifactId>tuna-bytes</artifactId>
     <packaging>pom</packaging>
-    <version>1.7.8</version>
+    <version>1.7.9</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         
         <lombok.version>1.18.26</lombok.version>
-        <base.version>1.7.8</base.version>
+        <base.version>1.7.9</base.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Migrate bunch of invalid mixin verification errors from runtime to compile time (invalid line numbers, invalid usage of @Mirror, @Overrite...)  
- fix @Mirror(value) remapping 
- unify algorithm for class narrowing